### PR TITLE
change a little bit of global models, and add gitignore for pycache

### DIFF
--- a/backend/enterprise/models.py
+++ b/backend/enterprise/models.py
@@ -1,30 +1,94 @@
 from django.db import models
 
 
-class Apply(models.Model):
+
+class Material(models.Model):
     id = models.IntegerField(primary_key=True)
-    workshopid = models.ForeignKey('Workshop', models.DO_NOTHING, db_column='workshopID')  # Field name made lowercase.
-    applier = models.CharField(max_length=45)
+    name = models.CharField(max_length=45)
+    class_field = models.CharField(db_column='class', max_length=45)  # Field renamed because it was a Python reserved word.
+
+    class Meta:
+        managed = True
+        db_table = 'material'
+
+
+class Order(models.Model):
+    id = models.IntegerField(primary_key=True)
     date = models.DateTimeField()
+    indentor = models.CharField(max_length=45)
+    recevier = models.CharField(max_length=45)
+    checker = models.CharField(max_length=45)
+    recevieraddress = models.CharField(db_column='recevierAddress', max_length=200)  # Field name made lowercase.
+    indentorphonenumber = models.CharField(db_column='indentorPhoneNumber', max_length=45)  # Field name made lowercase.
+    totalprice = models.DecimalField(db_column='totalPrice', max_digits=3, decimal_places=0)  # Field name made lowercase.
     status = models.CharField(max_length=45)
+    deliverydate = models.DateTimeField(db_column='deliveryDate')  # Field name made lowercase.
+    paymentway = models.CharField(db_column='paymentWay', max_length=45)  # Field name made lowercase.
 
     class Meta:
         managed = True
-        db_table = 'apply'
+        db_table = 'order'
+
+class Product(models.Model):
+    id = models.IntegerField(primary_key=True)
+    name = models.CharField(max_length=45)
+    class_field = models.CharField(db_column='class', max_length=45)  # Field renamed because it was a Python reserved word.
+    price = models.DecimalField(max_digits=3, decimal_places=0, blank=True, null=True)
+
+    class Meta:
+        managed = True
+        db_table = 'product'
+
+class Workshop(models.Model):
+    id = models.IntegerField(primary_key=True)
+    name = models.CharField(max_length=45)
+    productid = models.OneToOneField(Product, models.DO_NOTHING, db_column='productID')  # Field name made lowercase.
+    class Meta:
+        managed = True
+        db_table = 'workshop'
 
 
-class Applymaterial(models.Model):
-    applyid = models.ForeignKey(Apply, models.DO_NOTHING, db_column='applyID', primary_key=True)  # Field name made lowercase.
-    materialid = models.ForeignKey('Material', models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
+class Producetaskbasic(models.Model):
+    id = models.IntegerField(primary_key=True)
+    personincharge = models.CharField(db_column='personInCharge', max_length=45, blank=True, null=True)  # Field name made lowercase.
+    topic = models.CharField(max_length=45, blank=True, null=True)
+    producestatus = models.CharField(db_column='produceStatus', max_length=45, blank=True, null=True)  # Field name made lowercase.
+    accuratedate = models.DateTimeField(db_column='accurateDate', blank=True, null=True)  # Field name made lowercase.
+    workshopid = models.OneToOneField(Workshop, models.DO_NOTHING, db_column='workshopID', blank=True, null=True)  # Field name made lowercase.
+    orderid = models.OneToOneField(Order, models.DO_NOTHING, db_column='orderID', blank=True, null=True)  # Field name made lowercase.
     number = models.IntegerField()
+    begindate = models.DateTimeField(db_column='beginDate')  # Field name made lowercase.
+    deadline = models.DateTimeField()
+    class Meta:
+        managed = True
+        db_table = 'producetaskbasic'
+
+
+class Outwarehouse(models.Model):
+    id = models.IntegerField(primary_key=True)
+    outdate = models.DateTimeField(db_column='outDate')  # Field name made lowercase.
+    receiver = models.CharField(max_length=45)
+    checker = models.CharField(max_length=45)
 
     class Meta:
         managed = True
-        db_table = 'applymaterial'
-        unique_together = (('applyid', 'materialid'),)
+        db_table = 'outwarehouse'
+
+
+class Supplier(models.Model):
+    id = models.IntegerField(primary_key=True)
+    name = models.CharField(max_length=45)
+    contact = models.CharField(max_length=45)
+    phonenumber = models.CharField(db_column='phoneNumber', max_length=45)  # Field name made lowercase.
+    address = models.CharField(max_length=200)
+
+    class Meta:
+        managed = True
+        db_table = 'supplier'
+
 
 class Inventorinformation(models.Model):
-    materialid = models.ForeignKey('Material', models.DO_NOTHING, db_column='materialID', primary_key=True)  # Field name made lowercase.
+    materialid = models.OneToOneField('Material', models.DO_NOTHING, db_column='materialID', primary_key=True)  # Field name made lowercase.
     shelfnumber = models.CharField(db_column='shelfNumber', max_length=45, blank=True, null=True)  # Field name made lowercase.
     number = models.IntegerField(blank=True, null=True)
     threshold = models.IntegerField(blank=True, null=True)
@@ -46,9 +110,19 @@ class Inwarehouse(models.Model):
         db_table = 'inwarehouse'
 
 
+class Role(models.Model):
+    position = models.IntegerField(primary_key=True)
+    permission = models.CharField(max_length=32)
+    positionname = models.CharField(db_column='positionName', max_length=45)  # Field name made lowercase.
+
+    class Meta:
+        managed = True
+        db_table = 'role'
+
+
 class Inwarehouseproduct(models.Model):
-    inwarehouseid = models.ForeignKey(Inwarehouse, models.DO_NOTHING, db_column='inwarehouseID', primary_key=True)  # Field name made lowercase.
-    materialid = models.ForeignKey('Material', models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
+    inwarehouseid = models.OneToOneField(Inwarehouse, models.DO_NOTHING, db_column='inwarehouseID', primary_key=True)  # Field name made lowercase.
+    materialid = models.OneToOneField(Material, models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
     number = models.IntegerField()
 
     class Meta:
@@ -56,22 +130,12 @@ class Inwarehouseproduct(models.Model):
         db_table = 'inwarehouseproduct'
 
 
-class Material(models.Model):
-    id = models.IntegerField(primary_key=True)
-    name = models.CharField(max_length=45)
-    class_field = models.CharField(db_column='class', max_length=45)  # Field renamed because it was a Python reserved word.
-
-    class Meta:
-        managed = True
-        db_table = 'material'
-
-
 class Materialrequistion(models.Model):
     id = models.IntegerField(primary_key=True)
     distributiondate = models.DateTimeField(db_column='distributionDate', blank=True, null=True)  # Field name made lowercase.
     requistioner = models.CharField(max_length=45, blank=True, null=True)
     checker = models.CharField(max_length=45, blank=True, null=True)
-    workshopid = models.ForeignKey('Workshop', models.DO_NOTHING, db_column='workshopID', blank=True, null=True)  # Field name made lowercase.
+    workshopid = models.OneToOneField(Workshop, models.DO_NOTHING, db_column='workshopID', blank=True, null=True)  # Field name made lowercase.
     status = models.CharField(max_length=45, blank=True, null=True)
 
     class Meta:
@@ -79,27 +143,10 @@ class Materialrequistion(models.Model):
         db_table = 'materialrequistion'
 
 
-class Order(models.Model):
-    id = models.IntegerField(primary_key=True)
-    date = models.DateTimeField()
-    indentor = models.CharField(max_length=45)
-    recevier = models.CharField(max_length=45)
-    checker = models.CharField(max_length=45)
-    recevieraddress = models.CharField(db_column='recevierAddress', max_length=200)  # Field name made lowercase.
-    indentorphonenumber = models.CharField(db_column='indentorPhoneNumber', max_length=45)  # Field name made lowercase.
-    totalprice = models.DecimalField(db_column='totalPrice', max_digits=3, decimal_places=0)  # Field name made lowercase.
-    status = models.CharField(max_length=45)
-    deliverydate = models.DateTimeField(db_column='deliveryDate')  # Field name made lowercase.
-    paymentway = models.CharField(db_column='paymentWay', max_length=45)  # Field name made lowercase.
-
-    class Meta:
-        managed = True
-        db_table = 'order'
-
 
 class Orderproduct(models.Model):
-    orderid = models.ForeignKey(Order, models.DO_NOTHING, db_column='orderID', primary_key=True)  # Field name made lowercase.
-    productid = models.ForeignKey('Product', models.DO_NOTHING, db_column='productID')  # Field name made lowercase.
+    orderid = models.OneToOneField(Order, models.DO_NOTHING, db_column='orderID', primary_key=True)  # Field name made lowercase.
+    productid = models.OneToOneField(Product, models.DO_NOTHING, db_column='productID')  # Field name made lowercase.
     number = models.IntegerField()
     price = models.IntegerField()
 
@@ -110,8 +157,8 @@ class Orderproduct(models.Model):
 
 
 class Outproduct(models.Model):
-    outwarehouseid = models.ForeignKey('Outwarehouse', models.DO_NOTHING, db_column='outwarehouseID', primary_key=True)  # Field name made lowercase.
-    materialid = models.ForeignKey(Material, models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
+    outwarehouseid = models.OneToOneField(Outwarehouse, models.DO_NOTHING, db_column='outwarehouseID', primary_key=True)  # Field name made lowercase.
+    materialid = models.OneToOneField(Material, models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
     number = models.IntegerField()
 
     class Meta:
@@ -120,58 +167,10 @@ class Outproduct(models.Model):
         unique_together = (('outwarehouseid', 'materialid'),)
 
 
-class Outwarehouse(models.Model):
-    id = models.IntegerField(primary_key=True)
-    outdate = models.DateTimeField(db_column='outDate')  # Field name made lowercase.
-    receiver = models.CharField(max_length=45)
-    checker = models.CharField(max_length=45)
-
-    class Meta:
-        managed = True
-        db_table = 'outwarehouse'
-
-
-class Producetask(models.Model):
-    orderid = models.ForeignKey(Order, models.DO_NOTHING, db_column='orderID', primary_key=True)  # Field name made lowercase.
-    produceid = models.ForeignKey('Producetaskbasic', models.DO_NOTHING, db_column='produceID')  # Field name made lowercase.
-    number = models.IntegerField()
-    begindate = models.DateTimeField(db_column='beginDate')  # Field name made lowercase.
-    deadline = models.DateTimeField()
-
-    class Meta:
-        managed = True
-        db_table = 'producetask'
-        unique_together = (('orderid', 'produceid'),)
-
-
-class Producetaskbasic(models.Model):
-    id = models.IntegerField(primary_key=True)
-    personincharge = models.CharField(db_column='personInCharge', max_length=45, blank=True, null=True)  # Field name made lowercase.
-    topic = models.CharField(max_length=45, blank=True, null=True)
-    producestatus = models.CharField(db_column='produceStatus', max_length=45, blank=True, null=True)  # Field name made lowercase.
-    accuratedate = models.DateTimeField(db_column='accurateDate', blank=True, null=True)  # Field name made lowercase.
-    workshopid = models.ForeignKey('Workshop', models.DO_NOTHING, db_column='workshopID', blank=True, null=True)  # Field name made lowercase.
-    orderid = models.ForeignKey(Order, models.DO_NOTHING, db_column='orderID', blank=True, null=True)  # Field name made lowercase.
-
-    class Meta:
-        managed = True
-        db_table = 'producetaskbasic'
-
-
-class Product(models.Model):
-    id = models.IntegerField(primary_key=True)
-    name = models.CharField(max_length=45)
-    class_field = models.CharField(db_column='class', max_length=45)  # Field renamed because it was a Python reserved word.
-    price = models.DecimalField(max_digits=3, decimal_places=0, blank=True, null=True)
-
-    class Meta:
-        managed = True
-        db_table = 'product'
-
 
 class Productmaterial(models.Model):
-    productid = models.ForeignKey(Product, models.DO_NOTHING, db_column='productID', primary_key=True)  # Field name made lowercase.
-    materialid = models.ForeignKey(Material, models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
+    productid = models.OneToOneField(Product, models.DO_NOTHING, db_column='productID', primary_key=True)  # Field name made lowercase.
+    materialid = models.OneToOneField(Material, models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
     procedure = models.IntegerField(blank=True, null=True)
     number = models.IntegerField(blank=True, null=True)
     comments = models.CharField(max_length=800, blank=True, null=True)
@@ -188,7 +187,7 @@ class Purchase(models.Model):
     date = models.DateTimeField()
     checker = models.CharField(max_length=45)
     totalprice = models.DecimalField(db_column='totalPrice', max_digits=3, decimal_places=0)  # Field name made lowercase.
-    supplier = models.ForeignKey('Supplier', models.DO_NOTHING, db_column='supplier')
+    supplier = models.OneToOneField(Supplier, models.DO_NOTHING, db_column='supplier')
 
     class Meta:
         managed = True
@@ -196,8 +195,8 @@ class Purchase(models.Model):
 
 
 class Purchaseproduct(models.Model):
-    purchaseid = models.ForeignKey(Purchase, models.DO_NOTHING, db_column='purchaseID', primary_key=True)  # Field name made lowercase.
-    materialid = models.ForeignKey(Material, models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
+    purchaseid = models.OneToOneField(Purchase, models.DO_NOTHING, db_column='purchaseID', primary_key=True)  # Field name made lowercase.
+    materialid = models.OneToOneField(Material, models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
     number = models.IntegerField()
     price = models.DecimalField(max_digits=3, decimal_places=0)
 
@@ -207,8 +206,8 @@ class Purchaseproduct(models.Model):
 
 
 class Requisitionmaterial(models.Model):
-    requisitionid = models.ForeignKey(Materialrequistion, models.DO_NOTHING, db_column='requisitionID', primary_key=True)  # Field name made lowercase.
-    materialid = models.ForeignKey(Material, models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
+    requisitionid = models.OneToOneField(Materialrequistion, models.DO_NOTHING, db_column='requisitionID', primary_key=True)  # Field name made lowercase.
+    materialid = models.OneToOneField(Material, models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
     number = models.IntegerField()
 
     class Meta:
@@ -217,31 +216,9 @@ class Requisitionmaterial(models.Model):
         unique_together = (('requisitionid', 'materialid'),)
 
 
-class Role(models.Model):
-    position = models.IntegerField(primary_key=True)
-    permission = models.CharField(max_length=32)
-    positionname = models.CharField(db_column='positionName', max_length=45)  # Field name made lowercase.
-
-    class Meta:
-        managed = True
-        db_table = 'role'
-
-
-class Supplier(models.Model):
-    id = models.IntegerField(primary_key=True)
-    name = models.CharField(max_length=45)
-    contact = models.CharField(max_length=45)
-    phonenumber = models.CharField(db_column='phoneNumber', max_length=45)  # Field name made lowercase.
-    address = models.CharField(max_length=200)
-
-    class Meta:
-        managed = True
-        db_table = 'supplier'
-
-
 class Suppliermaterial(models.Model):
-    supplierid = models.ForeignKey(Supplier, models.DO_NOTHING, db_column='supplierID', primary_key=True)  # Field name made lowercase.
-    materialid = models.ForeignKey(Material, models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
+    supplierid = models.OneToOneField(Supplier, models.DO_NOTHING, db_column='supplierID', primary_key=True)  # Field name made lowercase.
+    materialid = models.OneToOneField(Material, models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
     price = models.DecimalField(max_digits=3, decimal_places=0, blank=True, null=True)
 
     class Meta:
@@ -256,7 +233,7 @@ class UserTable(models.Model):
     name = models.CharField(max_length=45, blank=True, null=True)
     gender = models.CharField(max_length=45)
     dateofentry = models.DateTimeField(db_column='dateOfEntry')  # Field name made lowercase.
-    position = models.ForeignKey(Role, models.DO_NOTHING, db_column='position')
+    position = models.OneToOneField(Role, models.DO_NOTHING, db_column='position')
     phonenumber = models.CharField(db_column='phoneNumber', max_length=45)  # Field name made lowercase.
     address = models.CharField(max_length=45)
 
@@ -265,10 +242,29 @@ class UserTable(models.Model):
         db_table = 'user_table'
 
 
-class Workshop(models.Model):
+
+''' 暂时保留, 姑且认为物料申请表和领料表是一回事
+反正别的组也不用
+class Apply(models.Model):
     id = models.IntegerField(primary_key=True)
-    name = models.CharField(max_length=45)
+    workshopid = models.OneToOneField(Workshop, models.DO_NOTHING, db_column='workshopID')  # Field name made lowercase.
+    applier = models.CharField(max_length=45)
+    date = models.DateTimeField()
+    status = models.CharField(max_length=45)
 
     class Meta:
         managed = True
-        db_table = 'workshop'
+        db_table = 'apply'
+
+
+class Applymaterial(models.Model):
+    applyid = models.OneToOneField(Apply, models.DO_NOTHING, db_column='applyID', primary_key=True)  # Field name made lowercase.
+    materialid = models.OneToOneField(Material, models.DO_NOTHING, db_column='materialID')  # Field name made lowercase.
+    number = models.IntegerField()
+
+    class Meta:
+        managed = True
+        db_table = 'applymaterial'
+        unique_together = (('applyid', 'materialid'),)
+
+'''


### PR DESCRIPTION
1. 因为生产管理部分可能要做多次级联搜索，且Django说OneToOneField更高效，特统一将外键字段改为OneToOneField
2. 经讨论，对生产计划表做了些修改
3. 暂时认为物料申请表和领料表是一码事，反正其他组也不用
4. 加了个gitignore，虽然只是忽略了pycache文件

请仔细帮我检查一下 辛苦啦！！